### PR TITLE
🐛 Fix a bug where getRiderImage was called without a rider

### DIFF
--- a/client/src/components/CardButton.js
+++ b/client/src/components/CardButton.js
@@ -44,7 +44,7 @@ const CardButton = ({ type, label = "", status, onClick }) => {
   const [imgIsLoading, setImgIsLoading] = useState(+true);
 
   useEffect(() => {
-    if (type === "rider") {
+    if (type === "rider" && label !== "") {
       const doFetch = async () => {
         const pic = await getRiderImage({ alias: label });
         setPicture(pic);


### PR DESCRIPTION
# Description

getRiderImage now only gets called, if there is a rider assigned.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
